### PR TITLE
Remove remote branches in `.git/config` w/ `gdel`

### DIFF
--- a/git/functions/gdel
+++ b/git/functions/gdel
@@ -16,5 +16,6 @@ EOF
 }
 
 # `$@` holds all arguments
+git branch --unset-upstream "$@" > /dev/null 2>&1
 git branch --delete --force "$@"
 git push origin --delete "$@"

--- a/git/functions/gdel
+++ b/git/functions/gdel
@@ -16,6 +16,8 @@ EOF
 }
 
 # `$@` holds all arguments
-git branch --unset-upstream "$@" > /dev/null 2>&1
+for branch in "$@"; do
+  git branch --unset-upstream "$branch" > /dev/null 2>&1
+done
 git branch --delete --force "$@"
 git push origin --delete "$@"


### PR DESCRIPTION
Swallow the potential error issued if it's not found; either there's no remote branch (fine), or there's no such branch at all, in which case the other commands will issue sufficient error