### PR TITLE
Add settings

### DIFF
--- a/.files-settings.json
+++ b/.files-settings.json
@@ -1,0 +1,7 @@
+{
+  "asdf": true,
+  "fzf": true,
+  "git-aliases": true,
+  "vi-mode": true,
+  "zsh": true
+}

--- a/git/alias.zsh
+++ b/git/alias.zsh
@@ -1,5 +1,7 @@
 #! /usr/bin/env zsh
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'git-aliases' || return 0
+
 # use hub if installed
 # https://github.com/github/hub
 command -v hub > /dev/null && alias git=hub

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -2,6 +2,8 @@
 
 Various infra-related scripts. Scripts without execute permissions used via `source`ing.
 
-- [`is_in_git_repo`](./is_in_git_repo) - determines if current script is running in a `git` repo
+- [`component_enabled.sh`](./component_enabled.sh) - tests if given component is enabled (keys to `false`)
+- [`is_in_git_repo.sh`](./is_in_git_repo) - determines if current script is running in a `git` repo
 - [`is_macos.sh`](./is_macos.sh) - exits with code 0 when the current operating system is `macOS` (determined via `uname`)
+- [`get_local_setting.sh`](./get_local_setting.sh) - gets the given key from the local settings file @ `$DOTFILES/.files-settings.json`
 - [`prompts.sh`](./prompts.sh) - provides pretty prompts for user interaction

--- a/infra/scripts/component_enabled.sh
+++ b/infra/scripts/component_enabled.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 
 ENABLED="$("$DOTFILES/infra/scripts/get_local_setting.sh" "$1")"
-[[ $ENABLED = true ]]
+[[ $ENABLED == true ]]

--- a/infra/scripts/component_enabled.sh
+++ b/infra/scripts/component_enabled.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+ENABLED="$("$DOTFILES/infra/scripts/get_local_setting.sh" "$1")"
+[[ $ENABLED = true ]]

--- a/infra/scripts/get_local_setting.sh
+++ b/infra/scripts/get_local_setting.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+jq --arg KEY "$1" '.[$KEY]' < "$DOTFILES/.files-settings.json"

--- a/utilities/fzf/fzf.zsh
+++ b/utilities/fzf/fzf.zsh
@@ -14,6 +14,8 @@
 # don't run unless `fzf` is installed
 command -v fzf > /dev/null || return
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'fzf' || return 0
+
 # Note: `$-` lists options set in current shell
 # ref - https://stackoverflow.com/questions/5163144/what-are-the-special-dollar-sign-shell-variables
 [[ $- == *i* ]] && {

--- a/utilities/fzf/git.zsh
+++ b/utilities/fzf/git.zsh
@@ -1,5 +1,7 @@
 #! /usr/bin/env zsh
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'fzf' || return 0
+
 # fzf ❤️ git
 # useful combinations of git & fzf
 # this file specifies keybinding for functions defined in `./functions.zsh`

--- a/zsh/asdf.zsh
+++ b/zsh/asdf.zsh
@@ -6,6 +6,8 @@
 #
 # see more details on `asdf` and my global config in `$DOTFILES/utilities/asdf`
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'asdf' || return 0
+
 # ref - https://asdf-vm.com/#/core-manage-asdf-vm?id=add-to-your-shell
 asdf_initialization="$HOMEBREW_PREFIX/opt/asdf/asdf.sh"
 [ -f "$asdf_initialization" ] && source "$asdf_initialization"

--- a/zsh/keymap.zsh
+++ b/zsh/keymap.zsh
@@ -8,6 +8,8 @@
 # `autoload`
 #   - `-U` -> alias expansion is supressed when the function is loaded
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'vi-mode' || return 0
+
 # turn on vim mode
 bindkey -v
 

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -10,6 +10,8 @@
   return 1
 }
 
+"$DOTFILES/infra/scripts/component_enabled.sh" 'zsh' || return 0
+
 # store tokens/keys in `secrets.zsh`, gitignored to avoid checking in
 [ -f "$DOTFILES/zsh/secrets.zsh" ] && source "$DOTFILES/zsh/secrets.zsh"
 


### PR DESCRIPTION
Add user-configurable settings. The MVP use case is flipping on or off
various parts of the config, including `fzf` (keybindings), `git`
aliases, `asdf`, etc.

Part of #70 